### PR TITLE
package.json files key

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
 		"ava": "^0.25.0",
 		"codecov": "^3.0.1",
 		"nyc": "^11.7.1"
-	}
+	},
+	"files": [
+		"index.js",
+		"README.md"
+	]
 }


### PR DESCRIPTION
Right now the NPM package has a size of 137kB, because the Yarn lockfile and other useless files are included. By specifying the `files` key in the `package.json` file, only the `index.js` file is included in the published package.